### PR TITLE
Build on linux

### DIFF
--- a/src/MetricUtils.cpp
+++ b/src/MetricUtils.cpp
@@ -57,14 +57,16 @@ extern size_t countNewlines( clang::StringRef& p_buffer )
 	return cnt;
 }
 
-#include <direct.h>
-#include "llvm/support/path.h"
-
 #ifdef LLVM_ON_WIN32
 #define HANDLE_CHAR_CASE( _x ) tolower(_x)
+#include <direct.h>
+#define getcwd _getcwd // stupid MSFT "deprecation" warning
 #else
 #define HANDLE_CHAR_CASE( _x ) (_x)
+#include <unistd.h>
 #endif
+
+#include "llvm/Support/Path.h"
 
 #if 0
 void test()
@@ -174,6 +176,6 @@ std::string makeRelative(const std::string& p_path, const std::string& p_cwd)
 
 std::string makeRelative(const std::string& p_path)
 {
-	const std::string cwd = _getcwd(NULL, 0);
+	const std::string cwd = getcwd(NULL, 0);
 	return makeRelative(p_path, cwd);
 }

--- a/src/MetricUtils.cpp
+++ b/src/MetricUtils.cpp
@@ -64,6 +64,8 @@ extern size_t countNewlines( clang::StringRef& p_buffer )
 #else
 #define HANDLE_CHAR_CASE( _x ) (_x)
 #include <unistd.h>
+#include <strings.h>
+#define stricmp strcasecmp
 #endif
 
 #include "llvm/Support/Path.h"


### PR DESCRIPTION
Hi

Here are two changes to make ccsm build on Linux again.
There is a bit more work to do, because the required ccsm_ver.h is created with a .BAT and on Linux we don't have that. For the time being I created my own shell script. But it probably should be written as a Python script.
