### PR TITLE
Refactor the gen_ver Python script

### DIFF
--- a/utils/gen_ver/gen_ver.py
+++ b/utils/gen_ver/gen_ver.py
@@ -3,55 +3,87 @@
 import subprocess
 import os
 import sys
+import argparse
 
-def make_ver( git_dir ):
-    ret_val = 1
-    string = ""
+
+def make_ver(git_dir=None):
+
+    # Get the version string
+    ver = subprocess.check_output(['git', 'describe', '--match', 'v[0-9]*', '--abbrev=7', 'HEAD'], cwd=git_dir)
+    # Check for local changes
+    chngs = subprocess.check_output(['git', 'diff-index', '--name-only', 'HEAD', '--'], cwd=git_dir)
+
+    ver_str = ver.rstrip()
+    if len(chngs) > 0:
+        ver_str += ".dirty"
+
+    txt = ["/* Generated automatically by {} */".format(os.path.basename(__file__)),
+           '#define GEN_VER_VERSION_STRING "{}"'.format(ver_str),
+           ]
+
+    return "\n".join(txt)
+
+
+class Usage(Exception):
+    """This class is used to catch user errors of argparse"""
+    def __init__(self, parser, msg):
+        self.parser = parser
+        self.msg = msg
+
+
+class NotGitRepo(Exception):
+    """This class is used to inform we need to be in a GIT directory"""
+    def __init__(self):
+        pass
+
+
+def main(argv=None):
+    parser = None
     try:
-        # Get the version string
-        ver = subprocess.check_output(['git','describe','--match','v[0-9]*','--abbrev=7','HEAD'],cwd=git_dir)
-        # Check for local changes
-        chngs = subprocess.check_output(['git','diff-index','--name-only','HEAD','--'],cwd=git_dir)
+        parser = argparse.ArgumentParser(description="Create an include file with a GIT version string")
+        parser.add_argument('hfile', metavar='HFILE', type=str,
+                            help='the name of the include file')
+        parser.add_argument('-v', '--verbose', action='store_true',
+                            help='be verbose')
+    except argparse.ArgumentError as msg:
+        # The construction of the parser failed
+        raise Usage(parser, msg)
 
-        ver_str = ver.rstrip();
-        if( len( chngs ) ):
-            ver_str += ".dirty"
+    args = parser.parse_args(argv)
+    # print(args)
 
-        string  = "/* Generated automatically by {} */\n"\
-                  '#define GEN_VER_VERSION_STRING "{}"'.format(os.path.basename(__file__),ver_str)
-        ret_val = 0
-    except subprocess.CalledProcessError, e:
-         string = "Failed to invoke git:\n", e.output
+    if not os.path.exists('.git'):
+        raise NotGitRepo()
 
-    return ret_val, string
+    version = make_ver()
+    if args.verbose:
+        print(version)
+
+    filename = args.hfile
+    if not os.path.exists(filename):
+        print("Creating new '{}'".format(filename))
+        open(filename, "w").write(version)
+    else:
+        old_version = open(args.hfile).read()
+        if old_version != version:
+            print("Version has changed, updating '{}'".format(filename))
+            open(filename, "w").write(version)
+        else:
+            print("Version has not changed, leaving '{}' as is".format(filename))
 
 if __name__ == '__main__':
-    ret_val = 1
-    if ( len( sys.argv ) < 2 ):
-        print "You must specify the output file as a parameter"
-    else:
-        filename = sys.argv[1]
-        if ( len( sys.argv ) > 2 ):
-            git_dir = sys.argv[2]
-        else:
-            git_dir = "."
-
-        code, string = make_ver( git_dir )
-
-        if( code != 0 ):
-            print string
-            ret_val = code
-        else:
-            content = ""
-            if( os.path.isfile( filename )):
-                with open(filename, 'r') as content_file:
-                    content = content_file.read()
-            if( content != string ):
-                print "Version has changed, updating '{}'".format(filename)
-                output_file = open(filename,'w')
-                output_file.write(string)
-            else:
-                print "Version has not changed, leaving '{}' as is".format(filename)
-            ret_val = 0
-
-    sys.exit( ret_val )
+    try:
+        main()
+    except Usage as usg:
+        # The construction of the argparser failed
+        usg.parser.error(usg.msg)
+    except NotGitRepo:
+        print("This must be execute from a GIT repo (directory)")
+    except subprocess.CalledProcessError, e:
+        print("Failed to invoke git:")
+        print(e.output)
+    except IOError as io:
+        print(io)
+    except SystemExit as e:
+        # print(e)
+        sys.exit(e)


### PR DESCRIPTION
Hi,

I've refactored the gen_ver Python script a bit.
I'm a fan of argparse. Now it's more more easy to add command line options.
For now I've changed it so that you must use the command from the toplevel where it sees the .git directory. It would be fairly easy to bring back your optional second command line arg with the git directory/
BTW, you shouldn't be using the name "string" for variables. It may be confusing, because it is a Python library.
