### PR TITLE
Add prefix-function-name & filename to CSV/TSV out

### DIFF
--- a/src/CcsmOptionsHandler.cpp
+++ b/src/CcsmOptionsHandler.cpp
@@ -166,6 +166,13 @@ static llvm::cl::opt<std::string> OutputToFile(
 	llvm::cl::Optional,
 	llvm::cl::cat(CCSMToolCategory));
 
+static llvm::cl::opt<bool> PrefixFunctionName(
+	"prefix-function-name",
+	llvm::cl::desc("Prefix function name with filename in output"),
+	llvm::cl::init(false),
+	llvm::cl::cat(CCSMToolCategory)
+	);
+
 static llvm::cl::list<std::string> LimitsFile(
 	"limits",
 	llvm::cl::desc("Specify a file to read limits data from"),
@@ -211,6 +218,7 @@ void CcsmOptionsHandler::ParseOptions(int argc,
 	m_metricOptions->setLimitsFile(LimitsFile);
 	// TODO: Handle failure
 	m_metricOptions->setOutputFile(OutputToFile);
+	m_metricOptions->setUsePrefix(PrefixFunctionName);
 
 	m_metricOptions->setOutputMetric(METRIC_UNIT_METHOD, !NoMethod);
 	m_metricOptions->setOutputMetric(METRIC_UNIT_FUNCTION, !NoFunction);

--- a/src/CcsmOptionsHandler.hpp
+++ b/src/CcsmOptionsHandler.hpp
@@ -32,9 +32,13 @@ private:
 	clang::tooling::CommonOptionsParser *m_optionsParser = NULL;
 	MetricOptions                       *m_metricOptions = NULL;
 
+	/** Indicates whether or not the C89/90 standard is specified for any of the files to be analysed */
 	bool m_usesC89 = false;
+	/** Indicates whether or not the C11 standard is specified for any of the files to be analysed */
 	bool m_usesC11 = false;
+	/** Indicates whether or not the C99 standard is specified for any of the files to be analysed */
 	bool m_usesC99 = false;
+	/** Indicates whether or not C++ is specified for any of the files to be analysed */
 	bool m_usesCpp = false;
 
 	void analyseCompilerArgs(const char* const exeName);

--- a/src/MetricDumper.cpp
+++ b/src/MetricDumper.cpp
@@ -93,7 +93,7 @@ void MetricDumper::dump(const MetricUnit* const p_topLevel, const MetricOptions&
 
 				if (metricUnitType == METRIC_UNIT_GLOBAL)
 				{
-					out << "Name" << sep;
+				out << "File" << sep << "Name" << sep;
 					int loop;
 					for (loop = 0;
 						loop < METRIC_TYPE_MAX;
@@ -139,7 +139,31 @@ void MetricDumper::dump(const MetricUnit* const p_topLevel, const MetricOptions&
 				out << m_namePrefix[metricUnitType];
 			}
 
+		if ((p_fmt == METRIC_DUMP_FORMAT_TSV) ||
+			(p_fmt == METRIC_DUMP_FORMAT_CSV)) 
+		{
+			if (metricUnitType == METRIC_UNIT_FUNCTION)
+			{
+				out << p_topLevel->getParent()->getUnitName(p_options) << sep;
+			}
+		}
+
+		if ((metricUnitType == METRIC_UNIT_FUNCTION) && 
+		    (p_options.getUsePrefix()))
+		{
+			out << p_topLevel->getParent()->getUnitName(p_options) << "::";
+		}
+
 			out << p_topLevel->getUnitName(p_options) << sep;
+
+		if ((p_fmt == METRIC_DUMP_FORMAT_TSV) ||
+			(p_fmt == METRIC_DUMP_FORMAT_CSV))
+		{
+			if (metricUnitType != METRIC_UNIT_FUNCTION)
+			{
+				out << sep;
+			}
+		}
 
 			unsigned loop;
 			for (loop = 0;

--- a/src/MetricOptions.cpp
+++ b/src/MetricOptions.cpp
@@ -289,6 +289,16 @@ std::string MetricOptions::getOutputFile(void) const
 	return m_outputFileName;
 }
 
+void MetricOptions::setUsePrefix(const bool p_prefix)
+{
+	m_usePrefix = p_prefix;
+}
+
+bool MetricOptions::getUsePrefix() const
+{
+	return m_usePrefix;
+}
+
 void MetricOptions::setLimitsFile(const std::vector<std::string>& p_fileName)
 {
 	m_limitsFileNames = p_fileName;

--- a/src/MetricOptions.hpp
+++ b/src/MetricOptions.hpp
@@ -60,6 +60,7 @@ protected:
 	std::ostream* m_outputStream       = NULL;
 	bool m_optionsOk                   = true;
 	std::map<std::string, bool> m_shouldIncludeFileCache;
+	bool m_usePrefix;
 
 	bool isFileInList( const std::vector<std::string>* const p_list, const std::string& p_name ) const;
 public:
@@ -96,6 +97,8 @@ public:
 	void setLimitsFile(const std::vector<std::string>& p_fileName);
 	const std::vector<std::string>& getLimitsFiles(void) const;
 	bool optionsOk(void) const;
+	void setUsePrefix(const bool p_prefix);
+	bool getUsePrefix() const;
 };
 
 #endif


### PR DESCRIPTION
Closes #81 by adding option & including filename in CVS/TSV output.