### PR TITLE
Rework path counting, fix for #125

### DIFF
--- a/src/MetricMatcher.cpp
+++ b/src/MetricMatcher.cpp
@@ -120,7 +120,7 @@ void MetricVisitor::UpdateCurrentFileName( const clang::SourceLocation &loc )
 
 MetricVisitor::PathResults MetricVisitor::getSwitchPathCount(const clang::SwitchStmt* const p_stmt, uint16_t depth)
 {
-	MetricVisitor::PathResults pathSum = { 0, false, 0, 0 };
+	MetricVisitor::PathResults pathSum = { 0, 0 };
 	// If the switch is based on an enum and all enum values are covered then effectively there should be no need for
 	//  a default
 	// TODO: Not necessarily true - just because an enum is being used it does not stop other values
@@ -151,8 +151,6 @@ MetricVisitor::PathResults MetricVisitor::getSwitchPathCount(const clang::Switch
 				if (subStmt != nullptr)
 				{
 					PathResults sub_count = getPathCount(subStmt, depth);
-					pathSum.path_count += sub_count.path_count;
-					pathSum.path_has_return = (pathSum.path_has_return || firstSubst) && sub_count.path_has_return;
 					pathSum.path_regular += sub_count.path_regular;
 					pathSum.path_return  += sub_count.path_return;
 					firstSubst = false;
@@ -174,7 +172,7 @@ MetricVisitor::PathResults MetricVisitor::getSwitchPathCount(const clang::Switch
 			switchCase = switchCase->getNextSwitchCase();
 
 #if defined( DEBUG_FN_TRACE_OUTOUT )
-			std::cout << blanks << "getSwitchPathCount - Updated: count - " << pathSum.path_count << " return - " << pathSum.path_has_return << std::endl;
+			std::cout << blanks << "getSwitchPathCount - Updated: regular " << pathSum.path_regular << ", return " << pathSum.path_return << std::endl;
 #endif
 
 		} while (switchCase != nullptr);
@@ -186,13 +184,11 @@ MetricVisitor::PathResults MetricVisitor::getSwitchPathCount(const clang::Switch
 #if defined( DEBUG_FN_TRACE_OUTOUT )
 		std::cout << blanks << "getSwitchPathCount - Adding implicit default" << std::endl;
 #endif
-		pathSum.path_count++;
 		pathSum.path_regular++;
-		pathSum.path_has_return = false;
 	}
 
 #if defined( DEBUG_FN_TRACE_OUTOUT )
-	std::cout << blanks << "getSwitchPathCount - Done: count - " << pathSum.path_count << " return - " << pathSum.path_has_return << std::endl;
+	std::cout << blanks << "getSwitchPathCount - Done: regular " << pathSum.path_regular << ", return " << pathSum.path_return << std::endl;
 #endif
 	
 	return pathSum;
@@ -201,7 +197,6 @@ MetricVisitor::PathResults MetricVisitor::getSwitchPathCount(const clang::Switch
 MetricVisitor::PathResults MetricVisitor::getIfPathCount(const clang::IfStmt* const p_stmt, uint16_t depth)
 {
 	MetricVisitor::PathResults ret_val;
-	MetricUnit::counter_t pathSum = 0;
 	MetricUnit::counter_t pathSum_regular = 0;
 	MetricUnit::counter_t pathSum_return = 0;
 	bool has_return = false;
@@ -218,9 +213,9 @@ MetricVisitor::PathResults MetricVisitor::getIfPathCount(const clang::IfStmt* co
 		/* Loops across 'if', 'else if' and 'else' constructs */
 		while (ifStmt != nullptr)
 		{
-			MetricVisitor::PathResults thenCount = { 1, false, 1, 0 };
+			MetricVisitor::PathResults thenCount = { 1, 0 };
 			/* Default to one gives an count for an implicit else block in the case that there is not one in the code */
-			MetricVisitor::PathResults elseCount = { 1, false, 1, 0 };
+			MetricVisitor::PathResults elseCount = { 1, 0 };
 
 			/* Get the path count for the 'then' block */
 			thenCount = getPathCount(ifStmt->getThen(), depth);
@@ -238,7 +233,6 @@ MetricVisitor::PathResults MetricVisitor::getIfPathCount(const clang::IfStmt* co
 					/* Process the contents of the 'else if' next time round the while */
 					ifStmt = static_cast<const clang::IfStmt*>(ifStmt->getElse());
 					/* No need to count an implicit else */
-					elseCount.path_count = 0;
 					elseCount.path_regular = 0;
 					elseCount.path_return = 0;
 				}
@@ -254,23 +248,15 @@ MetricVisitor::PathResults MetricVisitor::getIfPathCount(const clang::IfStmt* co
 				ifStmt = nullptr;
 			}
 
-#if defined( DEBUG_FN_TRACE_OUTOUT )
-			std::cout << blanks << "getIfPathCount - returns " << has_return << " - " << thenCount.path_has_return << " - " << elseCount.path_has_return << std::endl;
-#endif
-
-			pathSum += (thenCount.path_count + elseCount.path_count);
 			pathSum_regular += (thenCount.path_regular + elseCount.path_regular);
 			pathSum_return  += (thenCount.path_return  + elseCount.path_return);
-			has_return = has_return && (thenCount.path_has_return && ((elseCount.path_count == 0) || elseCount.path_has_return));
 		}
 	}
-	ret_val.path_count = pathSum;
-	ret_val.path_has_return = has_return;
 	ret_val.path_regular = pathSum_regular;
 	ret_val.path_return  = pathSum_return;
 
 #if defined( DEBUG_FN_TRACE_OUTOUT )
-	std::cout << blanks << "getIfPathCount - Updated: count - " << ret_val.path_count << " return - " << ret_val.path_has_return << std::endl;
+	std::cout << blanks << "getIfPathCount - Updated: regular " << ret_val.path_regular << ", return " << ret_val.path_return << std::endl;
 #endif
 
 	return ret_val;
@@ -283,8 +269,6 @@ MetricVisitor::PathResults MetricVisitor::getPathCount(const clang::Stmt* const 
 {
 	PathResults ret_val;
 	// TODO: Return this for null, too?
-	ret_val.path_has_return = false;
-	ret_val.path_count = 1;
 	ret_val.path_regular = 1;
 	ret_val.path_return  = 0;
 	// TODO: Need to check that there are no GOTOs before doing the path count
@@ -311,19 +295,19 @@ MetricVisitor::PathResults MetricVisitor::getPathCount(const clang::Stmt* const 
 				if( !isExprConstantAndFalse( static_cast<const clang::WhileStmt*>( p_stmt )->getCond() ) )
 				{
 					ret_val = getPathCount( ( static_cast<const clang::WhileStmt*>( p_stmt )->getBody() ), thisDepth );
-					ret_val.path_count += 1;
+					ret_val.path_regular += 1;
 				}
 				break;
 			case clang::Stmt::StmtClass::ForStmtClass:
 				ret_val = getPathCount((static_cast<const clang::ForStmt*>(p_stmt)->getBody()), thisDepth);
-				ret_val.path_count += 1;
+				ret_val.path_regular += 1;
 				break;
 			case clang::Stmt::StmtClass::DoStmtClass:
 				ret_val = getPathCount((static_cast<const clang::DoStmt*>(p_stmt)->getBody()), thisDepth);
 				/* If the condition is constant and false, this isn't a junction point, so don't increase the path count */
 				if( !isExprConstantAndFalse( static_cast<const clang::DoStmt*>( p_stmt )->getCond() ) )
 				{
-					ret_val.path_count += 1;
+					ret_val.path_regular += 1;
 				}
 				break;
 			default:
@@ -334,7 +318,7 @@ MetricVisitor::PathResults MetricVisitor::getPathCount(const clang::Stmt* const 
 	}
 
 #if defined( DEBUG_FN_TRACE_OUTOUT )
-	std::cout << blanks << "getPathCount - path_count " << ret_val.path_count << " has_return " << ret_val.path_has_return << std::endl;
+	std::cout << blanks << "getPathCount - regular " << ret_val.path_regular << ", return " << ret_val.path_return << std::endl;
 #endif
 
 	return ret_val;
@@ -361,8 +345,6 @@ MetricVisitor::PathResults MetricVisitor::getOtherPathCount(const clang::Stmt* c
 {
 	const clang::SourceLocation startLoc = p_stmt->getBeginLoc();
 	PathResults ret_val;
-	ret_val.path_has_return = false;
-	ret_val.path_count = 1;
 	ret_val.path_regular = 1;
 	ret_val.path_return  = 0;
 	// TODO: Need to check that there are no GOTOs before doing the path count
@@ -374,7 +356,6 @@ MetricVisitor::PathResults MetricVisitor::getOtherPathCount(const clang::Stmt* c
 	if (p_stmt->getStmtClass() == clang::Stmt::StmtClass::ReturnStmtClass)
 	{
 
-		ret_val.path_has_return = true;
 		/* No need to process any following statements, as they're inaccessible 
 		   TODO: unless there's a labelled statement that can receive a goto jump */
 		IncrementMetric(m_currentUnit, METRIC_TYPE_RETURNPOINTS, &startLoc);
@@ -387,7 +368,6 @@ MetricVisitor::PathResults MetricVisitor::getOtherPathCount(const clang::Stmt* c
 	else
 	{
 		bool skipAllSubsequent = false;
-		bool pathMissingReturn = false;
 		// Iterate all child statements
 		for (clang::Stmt::const_child_iterator it = p_stmt->child_begin();
 			it != p_stmt->child_end();
@@ -422,10 +402,8 @@ MetricVisitor::PathResults MetricVisitor::getOtherPathCount(const clang::Stmt* c
 					skipAllSubsequent = true;
 					break;
 				case clang::Stmt::StmtClass::ReturnStmtClass:
-					ret_val.path_has_return = true;
 					skipAllSubsequent = true;
 					IncrementMetric(m_currentUnit, METRIC_TYPE_RETURNPOINTS, &startLoc);
-					pathMissingReturn = false;
 
 					ret_val.path_return  = ret_val.path_regular;
 					ret_val.path_regular = 0;
@@ -442,24 +420,20 @@ MetricVisitor::PathResults MetricVisitor::getOtherPathCount(const clang::Stmt* c
 				case clang::Stmt::StmtClass::DoStmtClass:
 				case clang::Stmt::StmtClass::ForStmtClass:
 					sub_results = getPathCount(*it, depth);
-					if (sub_results.path_has_return)
+					if (sub_results.path_regular == 0)
 					{
 #if defined( DEBUG_FN_TRACE_OUTOUT )
 						std::cout << blanks << "getOtherPathCount - Path has a return statement" << std::endl;
 #endif
-						ret_val.path_has_return = true;
 						/* All paths had a return statement ... from now on, code should not be reachable */
 						skipAllSubsequent = true;
-						pathMissingReturn = false;
 					}
 					else
 					{
 #if defined( DEBUG_FN_TRACE_OUTOUT )
 						std::cout << blanks << "getOtherPathCount - Path is missing a return statement" << std::endl;
 #endif
-						pathMissingReturn = true;
 					}
-					ret_val.path_count *= sub_results.path_count;
 					ret_val.path_return  += ret_val.path_regular * sub_results.path_return;
 					ret_val.path_regular *= sub_results.path_regular;
 					break;
@@ -467,17 +441,13 @@ MetricVisitor::PathResults MetricVisitor::getOtherPathCount(const clang::Stmt* c
 					break;
 				}
 #if defined( DEBUG_FN_TRACE_OUTOUT )
-				std::cout << blanks << "getOtherPathCount - Updated: count - " << ret_val.path_count << " return - " << ret_val.path_has_return << " missing_return - " << pathMissingReturn << std::endl;
+				std::cout << blanks << "getOtherPathCount - Updated: regular - " << ret_val.path_regular << ", return " << ret_val.path_return << std::endl;
 #endif
 			}
 		}
-		if (pathMissingReturn)
-		{
-			ret_val.path_has_return = false;
-		}
 	}
 #if defined( DEBUG_FN_TRACE_OUTOUT )
-	std::cout << blanks << "getOtherPathCount - Done: count - " << ret_val.path_count << " return - " << ret_val.path_has_return << std::endl;
+	std::cout << blanks << "getOtherPathCount - Done: regular - " << ret_val.path_regular << ", return " << ret_val.path_return << std::endl;
 #endif
 
 	return ret_val;
@@ -580,9 +550,9 @@ bool MetricVisitor::VisitFunctionDecl(clang::FunctionDecl *func)
 
 			m_currentUnit->set( METRIC_TYPE_FUNCTION_PATHS, pathResults.path_regular + pathResults.path_return, getFileAndLine( SOURCE_MANAGER, &funcStartLoc ) );
 
-			if( !pathResults.path_has_return )
+			if( pathResults.path_regular != 0 )
 			{
-				/* Add an implicit return point */
+				/* Add an implicit return point if not all paths end in return */
 				IncrementMetric( m_currentUnit, METRIC_TYPE_RETURNPOINTS, &funcEndLoc );
 			}
 

--- a/src/MetricMatcher.hpp
+++ b/src/MetricMatcher.hpp
@@ -40,8 +40,13 @@ class MetricVisitor : public clang::RecursiveASTVisitor<MetricVisitor>
 protected:
 	typedef struct
 	{
+		// original
 		MetricUnit::counter_t path_count;
 		bool                  path_has_return;
+		// bk - number paths that don't end in return
+		MetricUnit::counter_t path_regular;
+		// bk - number paths that lead to return
+		MetricUnit::counter_t path_return;
 	} PathResults;
 
 	/** Table of pairs which match binary operators against metrics, used to initialise binaryOperatorToMetricMap */

--- a/src/MetricMatcher.hpp
+++ b/src/MetricMatcher.hpp
@@ -40,12 +40,9 @@ class MetricVisitor : public clang::RecursiveASTVisitor<MetricVisitor>
 protected:
 	typedef struct
 	{
-		// original
-		MetricUnit::counter_t path_count;
-		bool                  path_has_return;
-		// bk - number paths that don't end in return
+		//  number paths that don't end in return
 		MetricUnit::counter_t path_regular;
-		// bk - number paths that lead to return
+		// number paths that lead to return
 		MetricUnit::counter_t path_return;
 	} PathResults;
 

--- a/test/path/Makefile
+++ b/test/path/Makefile
@@ -1,0 +1,9 @@
+.phony: all
+
+all: test
+
+test: path_test.c
+	@ccsm --output-metrics=HIS_PATH --output-format=csv path_test.c 2> /dev/null | grep expected
+
+ast: path_test.c
+	 clang -Xclang -ast-dump -fsyntax-only path_test.c

--- a/test/path/path_test.c
+++ b/test/path/path_test.c
@@ -1,0 +1,299 @@
+
+void path_001_expected_1(void){
+}
+
+void path_002_expected_2(int a){
+    if (a){
+        // a = true
+    }
+}
+
+void path_003_expected_4(int a, int b){
+    if (a){
+        // a = true
+    }
+    //
+    if (b){
+        // b = true
+    }
+}
+
+void path_004_expected_3(int a, int b){
+    if (a){
+        // a = true
+        return;
+    }
+    //
+    if (b){
+        // b = true
+    }
+}
+
+void path_005_expected_4(int a, int b){
+    if (a){
+        // a = true
+    }
+    //
+    if (b){
+        // b = true
+        return;
+    }
+}
+
+void path_006_expected_5(int a, int b, int c){
+    if (a){
+        // a = true
+        return;
+    }
+    //
+    if (b){
+        // b = true
+    }
+    //
+    if (c){
+        // c = true
+    }
+}
+
+// ab, !ab,  a!bc, a!b!c,  !a!bc, !a!b!c
+void path_007_expected_6(int a, int b, int c){
+    if (a){
+        // a = true
+    }
+    //
+    if (b){
+        // b = true
+        return;
+    }
+    //
+    if (c){
+        // c = true
+    }
+}
+
+void path_008_expected_8(int a, int b, int c){
+    if (a){
+        // a = true
+    }
+    //
+    if (b){
+        // b = true
+    }
+    //
+    if (c){
+        // c = true
+        return;
+    }
+}
+
+void path_009_expected_4(int a, int b, int c){
+    if (a){
+        // a = true
+    }
+    //
+    else if (b){
+        // b = true
+    }
+    //
+    else if (c){
+        // c = true
+    }
+}
+
+void path_010_expected_3(int a){
+    switch (a){
+        case 0:
+            break;
+        case 1:
+            break;
+    }
+}
+
+void path_011_expected_6(int a, int b){
+    switch (a){
+        case 0:
+            break;
+        case 1:
+            break;
+    }
+    if (b){
+        // b = true
+    }
+}
+
+void path_012_expected_5(int a, int b){
+    switch (a){
+        case 0:
+            return;
+        case 1:
+            break;
+    }
+    if (b){
+        // b = true
+    }
+}
+
+void path_013_expected_5(int a, int b){
+    while (a){
+        if (b == 1){
+            return;
+        }
+        if (b == 2){
+            return;
+        }
+        if (b == 3){
+            return;
+        }
+        a--;
+    }
+}
+
+void path_014_expected_4(int a, int b, int c){
+    if (a){
+        return;
+    } else {
+        if (b){
+            return;
+        }  else {
+            if (c){
+                // c = true
+            } else {
+                // c = false
+            }
+        }
+    }
+}
+
+void path_015_expected_3(int a, int b, int c){
+    int i;
+    for (i = 0; i < 10; i++){
+        if (i > 5){
+            return;
+        }
+    }
+}
+
+void path_016_expected_8(int a, int b){
+    switch (a){
+        case 0:
+            if (a > 0) {
+                return;
+            }
+            break;
+        case 1:
+            if (a > 10) {
+                return;
+            }
+            break;
+        default:
+            break;
+    }
+    if (b){
+        // b = true
+    }
+}
+
+void path_017_expected_5(int a, int b){
+    switch (a){
+        case 0:
+            return;
+        case 1:
+            if (a > 10) {
+                return;
+            }
+            break;
+        case 2:
+            return;
+        default:
+            break;
+    }
+}
+
+void path_018_expected_7(int a, int b){
+    switch (a){
+        case 0:
+            return;
+        case 1:
+            if (a > 10) {
+                return;
+            }
+            break;
+        case 2:
+            return;
+        default:
+            break;
+    }
+    
+    if (b){
+        // b = true
+    }
+}
+
+void path_019_expected_4(int a, int b){
+    if (a > 10) {
+        while (a){
+            if (b == 1){
+                break;
+            }    
+        }
+    }
+}
+
+void path_020_expected_6(int a, int b){
+    if (a > 10) {
+        while (a){
+            if (b == 1){
+                continue;
+            }
+
+            if (b == 2){
+                break;
+            }    
+
+            return;
+        }
+    }
+}
+
+void path_021_expected_7(int a, int b){
+    while (b){
+        switch (a){
+            case 0:
+                return;
+            case 1:
+                switch (a){
+                    case 0:
+                        return;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                break;
+        }
+        if (b > 0){
+            b--;
+        }
+    }
+}
+
+
+void path_022_expected_10(int a, int b){
+    switch (a){
+        case 0:
+            if (b) break;
+            break;
+        case 1:
+            if (b) break;
+            break;
+        default:
+            break;
+    }
+    if (b > 0){
+        b--;
+    }
+}
+
+int main(int argc, char ** argv){
+    return 0;
+}


### PR DESCRIPTION
The main change in this PR is to count paths that lead to return separately from paths that do not. This allows for simpler reasoning about the path count. These can be simply added to get the total path count for the function.

We've added a few tests to be able to verify the updated algorithm and so far the calculated path count matches our expectation.