### PR TITLE
Check-out the compatible release/12.x branch of LLVM

### DIFF
--- a/utils/vagrant/buildit.sh
+++ b/utils/vagrant/buildit.sh
@@ -35,7 +35,7 @@ LLVM_DIR=llvm
 if [ -d $LLVM_DIR ]; then
     git -C $LLVM_DIR pull
 else
-    git clone https://github.com/llvm/llvm-project.git $LLVM_DIR
+    git clone https://github.com/llvm/llvm-project.git $LLVM_DIR --branch release/12.x
 fi
 
 CLANG_DIR=$LLVM_DIR/clang


### PR DESCRIPTION
Hi,

Last month, the ``CommonOptionsParser`` in LLVM was made ``protected`` making the build of CCSM on Linux crash. This PR ensures that the compatible branch is checked out.

Feel free to abandon this PR in favour of another PR that fixes the compatibility - or merge this one as an intermediate step.

