### PR TITLE
A few minor fixes for gen_ver.py

### DIFF
--- a/src/CcsmOptionsHandler.cpp
+++ b/src/CcsmOptionsHandler.cpp
@@ -159,7 +159,7 @@ static llvm::cl::opt<bool>
                          llvm::cl::desc("Enable condition analysis for path counting"),
                          llvm::cl::init(false), llvm::cl::cat(CCSMToolCategory));
 
-static llvm::cl::extrahelp MoreHelp("\nVersion: " GEN_VER_VERSION_STRING);
+static llvm::cl::extrahelp MoreHelp("\nVersion: " GEN_VER_VERSION_STRING "\n");
 
 static void PrintVersion(llvm::raw_ostream &OS) {
     OS << "CCSM (https://github.com/bright-tools/ccsm):" << '\n'

--- a/utils/gen_ver/gen_ver.py
+++ b/utils/gen_ver/gen_ver.py
@@ -20,7 +20,7 @@ def make_ver(git_dir=None):
            '#define GEN_VER_VERSION_STRING "{}"'.format(ver_str),
            ]
 
-    return "\n".join(txt)
+    return "\n".join(txt) + "\n"
 
 
 class Usage(Exception):

--- a/utils/gen_ver/gen_ver.py
+++ b/utils/gen_ver/gen_ver.py
@@ -11,13 +11,10 @@ if sys.version_info.major < 3:
 def make_ver(git_dir=None):
 
     # Get the version string
-    ver = subprocess.check_output(['git', 'describe', '--match', 'v[0-9]*', '--abbrev=7', 'HEAD'], cwd=git_dir, encoding='UTF-8')
-    # Check for local changes
-    chngs = subprocess.check_output(['git', 'diff-index', '--name-only', 'HEAD', '--'], cwd=git_dir, encoding='UTF-8')
+    ver = subprocess.check_output(['git', 'describe', '--tags', '--match', 'v[0-9]*', '--abbrev=7', '--dirty'],
+                                   cwd=git_dir, universal_newlines=True)
 
     ver_str = ver.rstrip()
-    if len(chngs) > 0:
-        ver_str += ".dirty"
 
     txt = ["/* Generated automatically by {} */".format(os.path.basename(__file__)),
            '#define GEN_VER_VERSION_STRING "{}"'.format(ver_str),


### PR DESCRIPTION
There are three changes:

- by using the `--tags` option to `git describe` we now get a better version (`v0.8` something instead of `v0.7` something)
- by using `--dirty` we don't need to check for changes with extra Python code
- the generated header file now gets a newline at the last line (as recommended by POSIX)